### PR TITLE
Resolved the twcc meta deta earlier as empty and resolved segmentation fault

### DIFF
--- a/examples/master/master.c
+++ b/examples/master/master.c
@@ -652,13 +652,13 @@ static void SampleSenderBandwidthEstimationHandler( void * pCustomContext,
     {
         pTwccMetaData = ( PeerConnectionTwccMetaData_t * ) pCustomContext;
 
-        pTwccMetaData->averagePacketLoss = EMA_ACCUMULATOR_GET_NEXT( pTwccMetaData->averagePacketLoss,
-                                                                     ( ( double ) percentLost ) );
-
         currentTimeUs = NetworkingUtils_GetCurrentTimeUs( NULL );
         lostPacketCount = pTwccBandwidthInfo->sentPackets - pTwccBandwidthInfo->receivedPackets;
         percentLost = ( double ) ( ( pTwccBandwidthInfo->sentPackets > 0 ) ? ( ( double ) ( lostPacketCount * 100 ) / ( double )pTwccBandwidthInfo->sentPackets ) : 0.0 );
         timeDifference = currentTimeUs - pTwccMetaData->lastAdjustmentTimeUs;
+
+        pTwccMetaData->averagePacketLoss = EMA_ACCUMULATOR_GET_NEXT( pTwccMetaData->averagePacketLoss,
+                                                                     ( ( double ) percentLost ) );
 
         if( timeDifference < PEER_CONNECTION_TWCC_BITRATE_ADJUSTMENT_INTERVAL_US )
         {

--- a/examples/peer_connection/peer_connection_codec_helper/peer_connection_g711_helper.c
+++ b/examples/peer_connection/peer_connection_codec_helper/peer_connection_g711_helper.c
@@ -163,6 +163,8 @@ PeerConnectionResult_t PeerConnectionG711Helper_WriteG711Frame( PeerConnectionSe
     uint32_t packetSent = 0;
     uint32_t bytesSent = 0;
     uint32_t randomRtpTimeoffset = 0;    // TODO : Spec required random rtp time offset ( current implementation of KVS SDK )
+    /* Add TWCC packet tracking */
+    TwccPacketInfo_t packetInfo;
 
     if( ( pSession == NULL ) ||
         ( pTransceiver == NULL ) ||
@@ -287,6 +289,15 @@ PeerConnectionResult_t PeerConnectionG711Helper_WriteG711Frame( PeerConnectionSe
                 pRollingBufferPacket->twccExtensionPayload = PEER_CONNECTION_SRTP_GET_TWCC_PAYLOAD( pSession->rtpConfig.twccId,
                                                                                                     pSession->rtpConfig.twccSequence );
                 pRollingBufferPacket->rtpPacket.header.extension.pExtensionPayload = &pRollingBufferPacket->twccExtensionPayload;
+
+                memset( &packetInfo, 0, sizeof( TwccPacketInfo_t ) );
+                packetInfo.packetSize = packetG711.packetDataLength;
+                packetInfo.localSentTime = NetworkingUtils_GetCurrentTimeUs( NULL );
+                packetInfo.packetSeqNum = pSession->rtpConfig.twccSequence;
+
+                RtcpTwccManager_AddPacketInfo( &pSession->pCtx->rtcpTwccManager,
+                                               &packetInfo );
+                                               
                 pSession->rtpConfig.twccSequence++;
             }
 

--- a/examples/peer_connection/peer_connection_codec_helper/peer_connection_h264_helper.c
+++ b/examples/peer_connection/peer_connection_codec_helper/peer_connection_h264_helper.c
@@ -164,6 +164,8 @@ PeerConnectionResult_t PeerConnectionH264Helper_WriteH264Frame( PeerConnectionSe
     uint32_t packetSent = 0;
     uint32_t bytesSent = 0;
     uint32_t randomRtpTimeoffset = 0;    // TODO : Spec required random rtp time offset ( current implementation of KVS SDK )
+    /* Add TWCC packet tracking */
+    TwccPacketInfo_t packetInfo;
 
     if( ( pSession == NULL ) ||
         ( pTransceiver == NULL ) ||
@@ -302,6 +304,15 @@ PeerConnectionResult_t PeerConnectionH264Helper_WriteH264Frame( PeerConnectionSe
                 pRollingBufferPacket->twccExtensionPayload = PEER_CONNECTION_SRTP_GET_TWCC_PAYLOAD( pSession->rtpConfig.twccId,
                                                                                                     pSession->rtpConfig.twccSequence );
                 pRollingBufferPacket->rtpPacket.header.extension.pExtensionPayload = &pRollingBufferPacket->twccExtensionPayload;
+
+                memset( &packetInfo, 0, sizeof( TwccPacketInfo_t ) );
+                packetInfo.packetSize = packetH264.packetDataLength;
+                packetInfo.localSentTime = NetworkingUtils_GetCurrentTimeUs( NULL );
+                packetInfo.packetSeqNum = pSession->rtpConfig.twccSequence;
+
+                RtcpTwccManager_AddPacketInfo( &pSession->pCtx->rtcpTwccManager,
+                                               &packetInfo );
+                                               
                 pSession->rtpConfig.twccSequence++;
             }
 

--- a/examples/peer_connection/peer_connection_codec_helper/peer_connection_opus_helper.c
+++ b/examples/peer_connection/peer_connection_codec_helper/peer_connection_opus_helper.c
@@ -163,6 +163,8 @@ PeerConnectionResult_t PeerConnectionOpusHelper_WriteOpusFrame( PeerConnectionSe
     uint32_t packetSent = 0;
     uint32_t bytesSent = 0;
     uint32_t randomRtpTimeoffset = 0;    // TODO : Spec required random rtp time offset ( current implementation of KVS SDK )
+    /* Add TWCC packet tracking */
+    TwccPacketInfo_t packetInfo;
 
     if( ( pSession == NULL ) ||
         ( pTransceiver == NULL ) ||
@@ -287,6 +289,15 @@ PeerConnectionResult_t PeerConnectionOpusHelper_WriteOpusFrame( PeerConnectionSe
                 pRollingBufferPacket->twccExtensionPayload = PEER_CONNECTION_SRTP_GET_TWCC_PAYLOAD( pSession->rtpConfig.twccId,
                                                                           pSession->rtpConfig.twccSequence );
                 pRollingBufferPacket->rtpPacket.header.extension.pExtensionPayload = &pRollingBufferPacket->twccExtensionPayload;
+
+                memset( &packetInfo, 0, sizeof( TwccPacketInfo_t ) );
+                packetInfo.packetSize = packetOpus.packetDataLength;
+                packetInfo.localSentTime = NetworkingUtils_GetCurrentTimeUs( NULL );
+                packetInfo.packetSeqNum = pSession->rtpConfig.twccSequence;
+
+                RtcpTwccManager_AddPacketInfo( &pSession->pCtx->rtcpTwccManager,
+                                               &packetInfo );
+                                               
                 pSession->rtpConfig.twccSequence++;
             }
 

--- a/examples/peer_connection/peer_connection_srtcp.c
+++ b/examples/peer_connection/peer_connection_srtcp.c
@@ -408,7 +408,7 @@ static PeerConnectionResult_t OnRtcpNackEvent( PeerConnectionSession_t * pSessio
             if( ( twccBandwidthInfo.duration > 0 ) && ( pSession->pCtx->onBandwidthEstimationCallback != NULL ) )
             {
                 /* Call the bandwidth estimation callback */
-                pSession->pCtx->onBandwidthEstimationCallback( pSession->pCtx->onBandwidthEstimationCallback,
+                pSession->pCtx->onBandwidthEstimationCallback( pSession->pCtx->pOnBandwidthEstimationCallbackContext,
                                                                &twccBandwidthInfo );
             }
 


### PR DESCRIPTION
### Description of changes:

This PR fixed the bug of TWCC meta data as 0 also fixes the Segmentation fault arises cause the Handler callback has a wrong input parameter.

## compile commands

Refer `README.md `

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
