### PR TITLE
Fix media not displaying on lower log level

### DIFF
--- a/examples/app_media_source/port/ameba_pro2/ameba_pro2_media_port.c
+++ b/examples/app_media_source/port/ameba_pro2/ameba_pro2_media_port.c
@@ -447,6 +447,7 @@ int32_t AppMediaSourcePort_Init( void )
                                               0, 0, 0, 0, 0,
                                               0, 0, 0, 0, 0,
                                               0, 0, 0 );
+        ( void ) voe_heap_size;
         LogInfo( ( "voe heap size = %d", voe_heap_size ) );
     }
 


### PR DESCRIPTION
*Issue #, if available:*
When log level is reduced from Info to Warning or NONE, media is not transmitted even though peer connection is established. 
*Description of changes:*
The compiler throws a error that `voe_heap_size` is not being used. 
Though we need `video_voe_presetting()` for the hardware, adding (` void ) voe_heap_size;` resolves the issue. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
