### PR TITLE
Reset PC state to init for next peer when detect long time no SDP scenario

### DIFF
--- a/examples/peer_connection/peer_connection.c
+++ b/examples/peer_connection/peer_connection.c
@@ -362,6 +362,9 @@ static PeerConnectionResult_t HandleRequest( PeerConnectionSession_t * pSession,
                 break;
             case PEER_CONNECTION_SESSION_REQUEST_TYPE_PEER_CONNECTION_CLOSE:
                 PeerConnection_CloseSession( pSession );
+
+                /* Reset the state to init for next peer since ICE negotiation has not started yet */
+                OnClosePeerConnection( pSession );
                 break;
             default:
                 /* Unknown request, drop it. */


### PR DESCRIPTION
*Issue #, if available:*
peer connection session is not able to recover from no time no SDP scenario.

*Description of changes:*
Reset the state back to init in this scenario because we don't need to wait for the close process from Ice Controller in this scenario. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
