### PR TITLE
Fix assertion failure and WiFi reconnection recovery

### DIFF
--- a/configs/lwip/lwipopts.h
+++ b/configs/lwip/lwipopts.h
@@ -45,6 +45,10 @@
 #define CONFIG_DYNAMIC_TICKLESS 0
 #endif
 
+#ifndef ENABLE_AMAZON_COMMON
+#define ENABLE_AMAZON_COMMON 1U
+#endif
+
 /* ---------- Memory options ---------- */
 /* MEM_ALIGNMENT: should be set to the alignment of the CPU for which
    lwIP is compiled. 4 byte alignment -> define MEM_ALIGNMENT to 4, 2
@@ -498,7 +502,7 @@ Certain platform allows computing and verifying the IP, UDP, TCP and ICMP checks
 /* Added by Realtek end */
 
 /* Extra options for lwip_v2.0.2 which should not affect lwip_v1.4.1 */
-#define LWIP_TCPIP_CORE_LOCKING         0
+#define LWIP_TCPIP_CORE_LOCKING         1
 #define LWIP_TCPIP_TIMEOUT              1
 #define LWIP_SO_RCVTIMEO                1
 #define LWIP_SOCKET_SET_ERRNO           0

--- a/configs/lwip/lwipopts.h
+++ b/configs/lwip/lwipopts.h
@@ -46,7 +46,7 @@
 #endif
 
 #ifndef ENABLE_AMAZON_COMMON
-#define ENABLE_AMAZON_COMMON 1U
+#define ENABLE_AMAZON_COMMON
 #endif
 
 /* ---------- Memory options ---------- */
@@ -502,7 +502,7 @@ Certain platform allows computing and verifying the IP, UDP, TCP and ICMP checks
 /* Added by Realtek end */
 
 /* Extra options for lwip_v2.0.2 which should not affect lwip_v1.4.1 */
-#define LWIP_TCPIP_CORE_LOCKING         1
+#define LWIP_TCPIP_CORE_LOCKING         0
 #define LWIP_TCPIP_TIMEOUT              1
 #define LWIP_SO_RCVTIMEO                1
 #define LWIP_SOCKET_SET_ERRNO           0


### PR DESCRIPTION
Description
------------
This PR addresses the following 2 issues:
1. Fix assertion failure in queue.c by enabling `LWIP_TCPIP_CORE_LOCKING` for thread safety.
2. Fix app recovery during WiFi reconnection by closing Peer Connection when a socket FD is unreachable.

Thank you @ActoryOu  for your changes and guidance. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
