### PR TITLE
Modularize External Libraries into Standalone CMake Targets

### DIFF
--- a/CMake/coreHTTP.cmake
+++ b/CMake/coreHTTP.cmake
@@ -1,0 +1,35 @@
+# This cmake file is used to include coreHTTP as static library.
+set(CMAKE_corehttp_DIRECTORY ${REPO_ROOT_DIRECTORY}/libraries/coreHTTP)
+include( ${CMAKE_corehttp_DIRECTORY}/httpFilePaths.cmake )
+
+add_library( corehttp )
+
+target_sources( corehttp
+    PRIVATE
+        ${HTTP_SOURCES}
+    PUBLIC
+        ${HTTP_INCLUDE_PUBLIC_DIRS}
+)
+
+target_include_directories( corehttp PUBLIC
+                            ${HTTP_INCLUDE_PUBLIC_DIRS}
+                            ${REPO_ROOT_DIRECTORY}/configs/corehttp
+                            ${REPO_ROOT_DIRECTORY}/examples/master # to get demo_config.h definition
+)
+
+# Suppress warnings for some Libraries
+file(GLOB_RECURSE HTTP_WARNING_SUPPRESSED_SOURCES
+    "${REPO_ROOT_DIRECTORY}/libraries/coreHTTP/source/dependency/3rdparty/llhttp/src/llhttp.c"
+)
+
+set_source_files_properties(
+    ${HTTP_WARNING_SUPPRESSED_SOURCES}
+    PROPERTIES
+    COMPILE_FLAGS "-w"
+)
+
+### add linked library ###
+list(
+    APPEND app_example_lib
+    corehttp
+)

--- a/CMake/coreJSON.cmake
+++ b/CMake/coreJSON.cmake
@@ -12,29 +12,10 @@ target_sources( corejson
 )
 
 target_include_directories( corejson PUBLIC
-                             ${JSON_INCLUDE_PUBLIC_DIRS} )
+                            ${JSON_INCLUDE_PUBLIC_DIRS} )
 
 ### add linked library ###
 list(
     APPEND app_example_lib
     corejson
 )
-
-# # DCEP library source files.
-# file(
-#   GLOB
-#   DCEP_SOURCES
-#   "${CMAKE_DCEP_DIRECTORY}/source/*.c" )
-
-# # DCEP library public include directories.
-# set( DCEP_INCLUDE_PUBLIC_DIRS
-#      "${CMAKE_DCEP_DIRECTORY}/source/include" )
-
-# add_library( dcep
-#              ${DCEP_SOURCES} )
-
-# target_include_directories( dcep PRIVATE
-#                             ${DCEP_INCLUDE_PUBLIC_DIRS} )
-
-# target_link_libraries( dcep PRIVATE )
-

--- a/CMake/coreJSON.cmake
+++ b/CMake/coreJSON.cmake
@@ -1,0 +1,40 @@
+# This cmake file is used to include coreJSON as static library.
+set(CMAKE_COREJSON_DIRECTORY ${REPO_ROOT_DIRECTORY}/libraries/coreJSON)
+include( ${CMAKE_COREJSON_DIRECTORY}/jsonFilePaths.cmake )
+
+add_library( corejson )
+
+target_sources( corejson
+    PRIVATE
+        ${JSON_SOURCES}
+    PUBLIC
+        ${JSON_INCLUDE_PUBLIC_DIRS}
+)
+
+target_include_directories( corejson PUBLIC
+                             ${JSON_INCLUDE_PUBLIC_DIRS} )
+
+### add linked library ###
+list(
+    APPEND app_example_lib
+    corejson
+)
+
+# # DCEP library source files.
+# file(
+#   GLOB
+#   DCEP_SOURCES
+#   "${CMAKE_DCEP_DIRECTORY}/source/*.c" )
+
+# # DCEP library public include directories.
+# set( DCEP_INCLUDE_PUBLIC_DIRS
+#      "${CMAKE_DCEP_DIRECTORY}/source/include" )
+
+# add_library( dcep
+#              ${DCEP_SOURCES} )
+
+# target_include_directories( dcep PRIVATE
+#                             ${DCEP_INCLUDE_PUBLIC_DIRS} )
+
+# target_link_libraries( dcep PRIVATE )
+

--- a/CMake/dcep.cmake
+++ b/CMake/dcep.cmake
@@ -11,10 +11,16 @@ file(
 set( DCEP_INCLUDE_PUBLIC_DIRS
      "${CMAKE_DCEP_DIRECTORY}/source/include" )
 
-add_library( dcep
-             ${DCEP_SOURCES} )
+add_library( dcep )
 
-target_include_directories( dcep PRIVATE
+target_sources( dcep
+    PRIVATE
+        ${DCEP_SOURCES}
+    PUBLIC
+        ${DCEP_INCLUDE_PUBLIC_DIRS}
+)
+
+target_include_directories( dcep PUBLIC
                             ${DCEP_INCLUDE_PUBLIC_DIRS} )
 
 target_link_libraries( dcep PRIVATE )

--- a/CMake/dcep.cmake
+++ b/CMake/dcep.cmake
@@ -1,4 +1,4 @@
-# This cmake file is used to include libwebsockets as static library.
+# This cmake file is used to include dcep as static library.
 set(CMAKE_DCEP_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../libraries/components/amazon-kinesis-video-streams-dcep)
 
 # DCEP library source files.

--- a/CMake/ice.cmake
+++ b/CMake/ice.cmake
@@ -1,9 +1,28 @@
-# ICE library source files.
-set( ICE_SOURCES
-     "${CMAKE_CURRENT_LIST_DIR}/../libraries/components/amazon-kinesis-video-streams-ice/source/ice_api.c"
-     "${CMAKE_CURRENT_LIST_DIR}/../libraries/components/amazon-kinesis-video-streams-ice/source/ice_api_private.c"
-     "${CMAKE_CURRENT_LIST_DIR}/../libraries/components/amazon-kinesis-video-streams-ice/source/transaction_id_store.c" )
+# This cmake file is used to include ICE as static library.
+set(CMAKE_ICE_DIRECTORY ${REPO_ROOT_DIRECTORY}/libraries/components/amazon-kinesis-video-streams-ice)
 
-# ICE library Public Include directories.
+# ICE library source files.
+file(
+  GLOB
+  ICE_SOURCES
+  "${CMAKE_ICE_DIRECTORY}/source/*.c" )
+
+# ICE library public include directories.
 set( ICE_INCLUDE_PUBLIC_DIRS
-     "${CMAKE_CURRENT_LIST_DIR}/../libraries/components/amazon-kinesis-video-streams-ice/source/include" )
+     "${CMAKE_ICE_DIRECTORY}/source/include" )
+
+add_library( ice
+             ${ICE_SOURCES} )
+
+target_include_directories( ice PUBLIC
+                            ${ICE_INCLUDE_PUBLIC_DIRS} )
+
+target_link_libraries( ice PRIVATE
+                       stun )
+
+### add linked library ###
+list(
+    APPEND app_example_lib
+    ice
+    stun
+)

--- a/CMake/libsrtp.cmake
+++ b/CMake/libsrtp.cmake
@@ -1,39 +1,46 @@
 cmake_minimum_required(VERSION 3.6)
+include( ${REPO_ROOT_DIRECTORY}/project/realtek_amebapro2_webrtc_application/GCC-RELEASE/includepath.cmake )
 
 project(libsrtp)
 set(libsrtp libsrtp)
 
 # libsrtp library source files.
 file(GLOB LIBSRTP_GLOB_SOURCES
-          ${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/kernel/*.c
-          ${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/math/*.c
-          ${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/replay/*.c
-          ${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/srtp/*.c )
+          ${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/kernel/*.c
+          ${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/math/*.c
+          ${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/replay/*.c
+          ${REPO_ROOT_DIRECTORY}/libraries/libsrtp/srtp/*.c )
 set(LIBSRTP_SOURCES
           ${LIBSRTP_GLOB_SOURCES}
-          "${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/cipher/aes.c"
-          "${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/cipher/aes_gcm_mbedtls.c"
-          "${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/cipher/aes_icm_mbedtls.c"
-          "${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/cipher/cipher.c"
-          "${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/cipher/cipher_test_cases.c"
-          "${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/cipher/null_cipher.c"
-          "${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/hash/auth_test_cases.c"
-          "${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/hash/auth.c"
-          "${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/hash/hmac.c"
-          "${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/hash/hmac_mbedtls.c"
-          "${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/hash/null_auth.c"
-          "${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/hash/sha1.c"
+          "${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/cipher/aes.c"
+          "${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/cipher/aes_gcm_mbedtls.c"
+          "${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/cipher/aes_icm_mbedtls.c"
+          "${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/cipher/cipher.c"
+          "${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/cipher/cipher_test_cases.c"
+          "${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/cipher/null_cipher.c"
+          "${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/hash/auth_test_cases.c"
+          "${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/hash/auth.c"
+          "${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/hash/hmac.c"
+          "${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/hash/hmac_mbedtls.c"
+          "${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/hash/null_auth.c"
+          "${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/hash/sha1.c"
           )
 
 # libsrtp library Public Include directories.
 set( LIBSRTP_INCLUDE_PUBLIC_DIRS
-     "${CMAKE_CURRENT_LIST_DIR}/../examples/libsrtp"
-     "${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/include"
-     "${CMAKE_CURRENT_LIST_DIR}/../libraries/libsrtp/crypto/include" )
+     "${REPO_ROOT_DIRECTORY}/examples/libsrtp"
+     "${REPO_ROOT_DIRECTORY}/libraries/libsrtp/include"
+     "${REPO_ROOT_DIRECTORY}/libraries/libsrtp/crypto/include" )
 
-add_library(
-     ${libsrtp} STATIC
-     ${LIBSRTP_SOURCES}
+add_library( ${libsrtp} )
+
+target_sources( ${libsrtp}
+    PRIVATE
+        ${LIBSRTP_SOURCES}
+    PUBLIC
+        ${LIBSRTP_INCLUDE_PUBLIC_DIRS}
+        ${inc_path}
+        ${REPO_ROOT_DIRECTORY}/libraries/ambpro2_sdk/component/os/freertos/${freertos}/Source/portable/GCC/ARM_CM33_NTZ/non_secure
 )
 
 list(
@@ -43,7 +50,6 @@ list(
 
 target_compile_definitions(${libsrtp} PRIVATE ${libsrtp_flags})
 
-include( ${CMAKE_CURRENT_LIST_DIR}/../project/realtek_amebapro2_webrtc_application/GCC-RELEASE/includepath.cmake )
 target_include_directories(
 	${libsrtp}
 	PUBLIC
@@ -55,5 +61,5 @@ target_include_directories(
 ### add linked library ###
 list(
     APPEND app_example_lib
-    libsrtp
+    ${libsrtp}
 )

--- a/CMake/rtcp.cmake
+++ b/CMake/rtcp.cmake
@@ -1,0 +1,20 @@
+# This cmake file is used to include rtcp as static library.
+include(${REPO_ROOT_DIRECTORY}/libraries/components/amazon-kinesis-video-streams-rtcp/rtcpFilePaths.cmake)
+
+add_library( rtcp )
+
+target_sources( rtcp
+    PRIVATE
+        ${RTCP_SOURCES}
+    PUBLIC
+        ${RTCP_INCLUDE_PUBLIC_DIRS}
+)
+
+target_include_directories( rtcp PUBLIC
+                            ${RTCP_INCLUDE_PUBLIC_DIRS} )
+
+### add linked library ###
+list(
+    APPEND app_example_lib
+    rtcp
+)

--- a/CMake/rtp.cmake
+++ b/CMake/rtp.cmake
@@ -1,0 +1,20 @@
+# This cmake file is used to include rtp as static library.
+include(${REPO_ROOT_DIRECTORY}/libraries/components/amazon-kinesis-video-streams-rtp/rtpFilePaths.cmake)
+
+add_library( rtp )
+
+target_sources( rtp
+    PRIVATE
+        ${RTP_SOURCES}
+    PUBLIC
+        ${RTP_INCLUDE_PUBLIC_DIRS}
+)
+
+target_include_directories( rtp PUBLIC
+                            ${RTP_INCLUDE_PUBLIC_DIRS} )
+
+### add linked library ###
+list(
+    APPEND app_example_lib
+    rtp
+)

--- a/CMake/sdp.cmake
+++ b/CMake/sdp.cmake
@@ -1,0 +1,23 @@
+# This cmake file is used to include SDP as static library.
+set(CMAKE_SDP_DIRECTORY ${REPO_ROOT_DIRECTORY}/libraries/components/amazon-kinesis-video-streams-sdp)
+include( ${CMAKE_SDP_DIRECTORY}/sdpFilePaths.cmake )
+
+add_library( sdp )
+
+target_sources( sdp
+    PRIVATE
+        ${SDP_SOURCES}
+    PUBLIC
+        ${SDP_INCLUDE_PUBLIC_DIRS}
+)
+
+target_include_directories( sdp PUBLIC
+                            ${SDP_INCLUDE_PUBLIC_DIRS} )
+
+target_compile_definitions( sdp PUBLIC SDP_DO_NOT_USE_CUSTOM_CONFIG )
+
+### add linked library ###
+list(
+    APPEND app_example_lib
+    sdp
+)

--- a/CMake/sigV4.cmake
+++ b/CMake/sigV4.cmake
@@ -1,10 +1,24 @@
 # This cmake file is used to include SigV4 as static library.
-set(CMAKE_SIGV4_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../libraries/crypto/SigV4-for-AWS-IoT-embedded-sdk)
+set(CMAKE_SIGV4_DIRECTORY ${REPO_ROOT_DIRECTORY}/libraries/crypto/SigV4-for-AWS-IoT-embedded-sdk)
 include( ${CMAKE_SIGV4_DIRECTORY}/sigv4FilePaths.cmake )
 
-add_library( sigv4_config
+add_library( sigv4
              ${SIGV4_SOURCES} )
 
-target_include_directories( sigv4_config PRIVATE
+target_sources( sigv4
+    PRIVATE
+        ${SIGV4_SOURCES}
+    PUBLIC
+        ${REPO_ROOT_DIRECTORY}/configs/sigv4
+        ${SIGV4_INCLUDE_PUBLIC_DIRS}
+)
+
+target_include_directories( sigv4 PUBLIC
                             ${REPO_ROOT_DIRECTORY}/configs/sigv4
                             ${SIGV4_INCLUDE_PUBLIC_DIRS} )
+
+### add linked library ###
+list(
+    APPEND app_example_lib
+    sigv4
+)

--- a/CMake/sigV4.cmake
+++ b/CMake/sigV4.cmake
@@ -6,5 +6,5 @@ add_library( sigv4_config
              ${SIGV4_SOURCES} )
 
 target_include_directories( sigv4_config PRIVATE
-                            ${CMAKE_ROOT_DIRECTORY}/configs/sigv4
+                            ${REPO_ROOT_DIRECTORY}/configs/sigv4
                             ${SIGV4_INCLUDE_PUBLIC_DIRS} )

--- a/CMake/sigV4.cmake
+++ b/CMake/sigV4.cmake
@@ -1,4 +1,4 @@
-# This cmake file is used to include libwebsockets as static library.
+# This cmake file is used to include SigV4 as static library.
 set(CMAKE_SIGV4_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../libraries/crypto/SigV4-for-AWS-IoT-embedded-sdk)
 include( ${CMAKE_SIGV4_DIRECTORY}/sigv4FilePaths.cmake )
 

--- a/CMake/signaling.cmake
+++ b/CMake/signaling.cmake
@@ -1,0 +1,26 @@
+# This cmake file is used to include Signaling as static library.
+set(CMAKE_SIGNALING_DIRECTORY ${REPO_ROOT_DIRECTORY}/libraries/components/amazon-kinesis-video-streams-signaling)
+include( ${CMAKE_SIGNALING_DIRECTORY}/signalingFilePaths.cmake )
+
+add_library( signaling )
+
+target_sources( signaling
+    PRIVATE
+        ${SIGNALING_SOURCES}
+    PUBLIC
+        ${SIGNALING_INCLUDE_PUBLIC_DIRS}
+)
+
+target_include_directories( signaling PUBLIC
+                            ${SIGNALING_INCLUDE_PUBLIC_DIRS} )
+
+target_link_libraries( signaling PRIVATE
+                       corejson )
+
+target_compile_definitions( signaling PUBLIC SIGNALING_DO_NOT_USE_CUSTOM_CONFIG )
+
+### add linked library ###
+list(
+    APPEND app_example_lib
+    signaling
+)

--- a/CMake/stun.cmake
+++ b/CMake/stun.cmake
@@ -1,0 +1,30 @@
+# This cmake file is used to include STUN as static library.
+set(CMAKE_STUN_DIRECTORY ${REPO_ROOT_DIRECTORY}/libraries/components/amazon-kinesis-video-streams-stun)
+
+# STUN library source files.
+file(
+  GLOB
+  STUN_SOURCES
+  "${CMAKE_STUN_DIRECTORY}/source/*.c" )
+
+# STUN library public include directories.
+set( STUN_INCLUDE_PUBLIC_DIRS
+     "${CMAKE_STUN_DIRECTORY}/source/include" )
+
+add_library( stun )
+
+target_sources( stun
+    PRIVATE
+        ${STUN_SOURCES}
+    PUBLIC
+        ${STUN_INCLUDE_PUBLIC_DIRS}
+)
+
+target_include_directories( stun PUBLIC
+                            ${STUN_INCLUDE_PUBLIC_DIRS} )
+
+### add linked library ###
+list(
+    APPEND app_example_lib
+    stun
+)

--- a/CMake/usrsctp.cmake
+++ b/CMake/usrsctp.cmake
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.6)
+include( ${REPO_ROOT_DIRECTORY}/project/realtek_amebapro2_webrtc_application/GCC-RELEASE/includepath.cmake )
 
 project(usrsctp)
 
@@ -8,36 +9,50 @@ list(
     APPEND usrsctp_sources
 
 ###netinet
-    ${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_asconf.c
-    ${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_auth.c
-    ${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_bsd_addr.c
-    ${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_callout.c
-    ${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_cc_functions.c
-    ${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_crc32.c
-    ${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_indata.c
-	${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_input.c
-	${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_output.c
-	${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_pcb.c
-	${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_peeloff.c
-	${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_sha1.c
-	${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_ss_functions.c
-	${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_sysctl.c
-	${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_timer.c
-	${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_userspace.c
-	${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctp_usrreq.c
-	${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet/sctputil.c
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_asconf.c
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_auth.c
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_bsd_addr.c
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_callout.c
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_cc_functions.c
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_crc32.c
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_indata.c
+	${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_input.c
+	${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_output.c
+	${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_pcb.c
+	${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_peeloff.c
+	${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_sha1.c
+	${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_ss_functions.c
+	${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_sysctl.c
+	${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_timer.c
+	${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_userspace.c
+	${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctp_usrreq.c
+	${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet/sctputil.c
 ###netinet6
-    ${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet6/sctp6_usrreq.c
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet6/sctp6_usrreq.c
 
-    ${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/user_environment.c
-    ${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/user_mbuf.c
-    ${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/user_recv_thread.c
-    ${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/user_socket.c
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/user_environment.c
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/user_mbuf.c
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/user_recv_thread.c
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/user_socket.c
 )
 
-add_library(
-    ${usrsctp} STATIC
-    ${usrsctp_sources}
+list(
+    APPEND usrsctp_include
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet
+    ${REPO_ROOT_DIRECTORY}/libraries/usrsctp/usrsctplib/netinet6
+)
+
+add_library( ${usrsctp} )
+
+target_sources( ${usrsctp}
+    PRIVATE
+        ${usrsctp_sources}
+        ${REPO_ROOT_DIRECTORY}/project/realtek_amebapro2_webrtc_application/src/amazon_kvs/lib_amazon/gcc_include
+    PUBLIC
+        ${inc_path}
+        ${REPO_ROOT_DIRECTORY}/libraries/ambpro2_sdk/component/os/freertos/${freertos}/Source/portable/GCC/ARM_CM33_NTZ/non_secure
+        ${usrsctp_include}
 )
 
 list(
@@ -67,26 +82,15 @@ list(
     KVS_PLAT_RTK_FREERTOS
 )
 
-target_compile_definitions(${usrsctp} PUBLIC ${usrsctp_flags} )
+target_compile_definitions( ${usrsctp} PUBLIC ${usrsctp_flags} )
 
-include( ${CMAKE_CURRENT_LIST_DIR}/../project/realtek_amebapro2_webrtc_application/GCC-RELEASE/includepath.cmake )
-
-target_include_directories(
-	${usrsctp}
-	PUBLIC
-
-    ${inc_path}
-	${sdk_root}/component/os/freertos/${freertos}/Source/portable/GCC/ARM_CM33_NTZ/non_secure
-
-	${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib
-    ${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet
-    ${CMAKE_CURRENT_LIST_DIR}/../libraries/usrsctp/usrsctplib/netinet6
-)
-
-target_include_directories(
-	${usrsctp}
+target_include_directories( ${usrsctp}
     PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR}/../project/realtek_amebapro2_webrtc_application/src/amazon_kvs/lib_amazon/gcc_include
+        ${REPO_ROOT_DIRECTORY}/project/realtek_amebapro2_webrtc_application/src/amazon_kvs/lib_amazon/gcc_include
+    PUBLIC
+        ${inc_path}
+        ${REPO_ROOT_DIRECTORY}/libraries/ambpro2_sdk/component/os/freertos/${freertos}/Source/portable/GCC/ARM_CM33_NTZ/non_secure
+        ${usrsctp_include}
 )
 
 ### add linked library ###
@@ -94,4 +98,3 @@ list(
     APPEND app_example_lib
     usrsctp
 )
-

--- a/CMake/wslay.cmake
+++ b/CMake/wslay.cmake
@@ -1,0 +1,40 @@
+# This cmake file is used to include Wslay as static library.
+include( ${REPO_ROOT_DIRECTORY}/project/realtek_amebapro2_webrtc_application/GCC-RELEASE/includepath.cmake )
+
+file(
+  GLOB
+  WSLAY_SOURCE_FILES
+  "${REPO_ROOT_DIRECTORY}/libraries/wslay/lib/*.c" )
+
+configure_file(${REPO_ROOT_DIRECTORY}/libraries/wslay/lib/includes/wslay/wslayver.h.in
+               ${REPO_ROOT_DIRECTORY}/libraries/wslay/lib/includes/wslay/wslayver.h @ONLY)
+
+set( WSLAY_INCLUDE_DIRS
+     "${REPO_ROOT_DIRECTORY}/libraries/wslay/lib/"
+     "${REPO_ROOT_DIRECTORY}/libraries/wslay/lib/includes"
+     "${REPO_ROOT_DIRECTORY}/libraries/wslay/lib/includes/wslay"
+     "${REPO_ROOT_DIRECTORY}/configs/wslay" )
+
+add_library( wslay )
+
+target_sources( wslay
+    PRIVATE
+        ${WSLAY_SOURCE_FILES}
+    PUBLIC
+        ${WSLAY_INCLUDE_DIRS}
+        ${inc_path}
+        ${REPO_ROOT_DIRECTORY}/libraries/ambpro2_sdk/component/os/freertos/${freertos}/Source/portable/GCC/ARM_CM33_NTZ/non_secure
+)
+
+target_include_directories( wslay PUBLIC
+                            ${WSLAY_INCLUDE_DIRS}
+                            ${inc_path}
+                            ${REPO_ROOT_DIRECTORY}/libraries/ambpro2_sdk/component/os/freertos/${freertos}/Source/portable/GCC/ARM_CM33_NTZ/non_secure )
+
+target_compile_definitions( wslay PUBLIC HAVE_ARPA_INET_H )
+
+### add linked library ###
+list(
+    APPEND app_example_lib
+    wslay
+)

--- a/configs/corehttp/core_http_config.h
+++ b/configs/corehttp/core_http_config.h
@@ -17,17 +17,7 @@
 #ifndef CORE_HTTP_CONFIG_H_
 #define CORE_HTTP_CONFIG_H_
 
-#include "logging.h"
 #include "demo_config.h"
-
-/* Logging configuration for the HTTP library. */
-#ifndef LIBRARY_LOG_NAME
-#define LIBRARY_LOG_NAME    "HTTP"
-#endif
-
-#ifndef LIBRARY_LOG_LEVEL
-#define LIBRARY_LOG_LEVEL    LOG_INFO
-#endif
 
 #define HTTP_USER_AGENT_VALUE AWS_KVS_AGENT_NAME
 

--- a/configs/sigv4/sigv4_config.h
+++ b/configs/sigv4/sigv4_config.h
@@ -36,8 +36,6 @@
 #ifndef SIGV4_CONFIG_H_
 #define SIGV4_CONFIG_H_
 
-#include "logging.h"
-
 #define SIGV4_PROCESSING_BUFFER_LENGTH    2048U
 
 #endif /* ifndef SIGV4_CONFIG_H_ */

--- a/examples/ice_controller/ice_controller.c
+++ b/examples/ice_controller/ice_controller.c
@@ -1249,7 +1249,7 @@ IceControllerResult_t IceController_DeserializeIceCandidate( const char * pDecod
     IceControllerResult_t ret = ICE_CONTROLLER_RESULT_OK;
     StringUtilsResult_t stringResult;
     const char * pCandidateString;
-    size_t candidateStringLength;
+    size_t candidateStringLength = 0;
     const char * pCurr, * pTail, * pNext;
     size_t tokenLength;
     IceControllerCandidateDeserializerState_t deserializerState = ICE_CONTROLLER_CANDIDATE_DESERIALIZER_STATE_FOUNDATION;

--- a/examples/network_transport/transport_dtls_mbedtls.c
+++ b/examples/network_transport/transport_dtls_mbedtls.c
@@ -641,50 +641,51 @@ int32_t DTLS_CreateCertificateFingerprint( const mbedtls_x509_crt * pCert,
         /* Empty else marker. */
     }
 
-    pMdInfo = mbedtls_md_info_from_type( MBEDTLS_MD_SHA256 );
-    if( pMdInfo == NULL )
+    if( retStatus == 0 )
     {
-        LogError( ( "invalid input, pMdInfo == NULL " ) );
-        retStatus = -1;
-    }
-    else
-    {
-        /* Empty else marker. */
-    }
-
-    sslRet = mbedtls_sha256_ret( pCert->raw.p,
-                                 pCert->raw.len,
-                                 fingerprint,
-                                 0 );
-    if( sslRet != 0 )
-    {
-        LogError( ( "Failed to calculate the SHA-256 checksum: mbedTLSError= %s : %s.", mbedtlsHighLevelCodeOrDefault( sslRet ), mbedtlsLowLevelCodeOrDefault( sslRet ) ) );
-    }
-    else
-    {
-        /* Empty else marker. */
+        pMdInfo = mbedtls_md_info_from_type( MBEDTLS_MD_SHA256 );
+        if( pMdInfo == NULL )
+        {
+            LogError( ( "invalid input, pMdInfo == NULL " ) );
+            retStatus = -1;
+        }
     }
 
-    size = mbedtls_md_get_size( pMdInfo );
+    if( retStatus == 0 )
+    {
+        sslRet = mbedtls_sha256_ret( pCert->raw.p,
+                                     pCert->raw.len,
+                                     fingerprint,
+                                     0 );
+        if( sslRet != 0 )
+        {
+            LogError( ( "Failed to calculate the SHA-256 checksum: mbedTLSError= %s : %s.", mbedtlsHighLevelCodeOrDefault( sslRet ), mbedtlsLowLevelCodeOrDefault( sslRet ) ) );
+            retStatus = -1;
+        }
+    }
 
-    if( bufLen < 3 * size )
+    if( retStatus == 0 )
     {
-        LogError( ( "buffer to store fingerprint too small buffer: %i size: %li", bufLen, size ) );
-        retStatus = -1;
-    }
-    else
-    {
-        /* Empty else marker. */
+        size = mbedtls_md_get_size( pMdInfo );
+
+        if( bufLen < 3 * size )
+        {
+            LogError( ( "buffer to store fingerprint too small buffer: %i size: %li", bufLen, size ) );
+            retStatus = -1;
+        }
     }
 
-    for( i = 0; i < size; i++ )
+    if( retStatus == 0 )
     {
-        sprintf( pBuff,
-                 "%.2X:",
-                 fingerprint[i] );
-        pBuff += 3;
+        for( i = 0; i < size; i++ )
+        {
+            sprintf( pBuff,
+                     "%.2X:",
+                     fingerprint[i] );
+            pBuff += 3;
+        }
+        *( pBuff - 1 ) = '\0';
     }
-    *( pBuff - 1 ) = '\0';
 
     return retStatus;
 }

--- a/project/realtek_amebapro2_webrtc_application/GCC-RELEASE/includepath.cmake
+++ b/project/realtek_amebapro2_webrtc_application/GCC-RELEASE/includepath.cmake
@@ -17,32 +17,11 @@ list (
     "${sdk_root}/component/soc/8735b/cmsis/rtl8735b/include"
     
     "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/include"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac/halmac_88xx"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/host/storage/inc/quirks"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/device/class/ethernet/inc"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac/halmac_88xx/halmac_8822b"
     "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/include"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/device/class/ethernet/src"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/device/core/inc"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac/halmac_88xx/halmac_8735b"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac/halmac_88xx_v1"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/device/class/vendor/inc"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/host/storage/inc"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/host/storage/inc/scatterlist"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac/halmac_88xx/halmac_8821c"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/host/vendor_spec"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac/halmac_88xx_v1/halmac_8814b"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/host/storage/inc/scsi"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/inc"
-    "${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac/halmac_88xx/halmac_8195b"
-	"${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/device"
     
     "${sdk_root}/component/soc/8735b/misc/utilities/include"
     
     "${sdk_root}/component/soc/8735b/app/stdio_port"
-    "${sdk_root}/component/soc/8735b/app/xmodem/rom"
     "${sdk_root}/component/soc/8735b/app/shell"
     "${sdk_root}/component/soc/8735b/app/shell/rom_ns"
     "${sdk_root}/component/soc/8735b/app/rtl_printf/include"
@@ -53,12 +32,6 @@ list (
     
     "${sdk_root}/component/wifi/driver/include"
     "${sdk_root}/component/wifi/driver/src/osdep"
-	"${sdk_root}/component/wifi/driver/src/phl"
-    "${sdk_root}/component/wifi/driver/src/hal"
-    "${sdk_root}/component/wifi/driver/src/hal/halmac"
-    "${sdk_root}/component/wifi/driver/src/hci"
-    "${sdk_root}/component/wifi/driver/src/hal/phydm/rtl8735b"
-    "${sdk_root}/component/wifi/driver/src/hal/phydm"
     "${sdk_root}/component/wifi/wpa_supplicant/wpa_supplicant"
 
     "${sdk_root}/component/os/freertos/freertos_posix/lib/include/FreeRTOS_POSIX"
@@ -81,7 +54,6 @@ list (
 	"${sdk_root}/component/usb/usb_class/device/class"
 	"${sdk_root}/component/usb/usb_class/device"
 	"${sdk_root}/component/usb/usb_class/host/uvc/inc"
-	"${sdk_root}/component/video/driver/common"
 	"${sdk_root}/component/video/driver/RTL8735B"
 	"${sdk_root}/component/media/rtp_codec"
 	"${sdk_root}/component/media/samples"
@@ -123,8 +95,6 @@ list (
 	
 	"${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/video"
 	"${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/video/semihost"
-	"${sdk_root}/component/soc/8735b/cmsis/voe/rom"
-	   
 )
 
 get_filename_component(inc_path "${inc_path_re}" ABSOLUTE)
@@ -143,37 +113,15 @@ include_directories (${sdk_root}/component/usb/usb_class/device/class )
 include_directories (${sdk_root}/component/usb/usb_class/device )
 include_directories (${sdk_root}/component/usb/usb_class/host/uvc/inc )
 include_directories (${sdk_root}/component/video/v4l2/inc )
-include_directories (${sdk_root}/component/video/driver/common )
 include_directories (${sdk_root}/component/media/rtp_codec )
 include_directories (${sdk_root}/component/media/samples )
 
 include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/include )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac/halmac_88xx )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/host/storage/inc/quirks )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/device/class/ethernet/inc )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac/halmac_88xx/halmac_8822b )
 include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/include )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/device/class/ethernet/src )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/device/core/inc )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac/halmac_88xx/halmac_8735b )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac/halmac_88xx_v1 )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/device/class/vendor/inc )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/host/storage/inc )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/host/storage/inc/scatterlist )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac/halmac_88xx/halmac_8821c )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/host/vendor_spec )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac/halmac_88xx_v1/halmac_8814b )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/host/storage/inc/scsi )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/inc )
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/source/ram_ns/halmac/halmac_88xx/halmac_8195b)
-include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/usb_otg/device )
 
 include_directories (${sdk_root}/component/soc/8735b/misc/utilities/include )
 
 include_directories (${sdk_root}/component/soc/8735b/app/stdio_port )
-include_directories (${sdk_root}/component/soc/8735b/app/xmodem/rom )
 include_directories (${sdk_root}/component/soc/8735b/app/shell )
 include_directories (${sdk_root}/component/soc/8735b/app/shell/rom_ns )
 include_directories (${sdk_root}/component/soc/8735b/app/rtl_printf/include )
@@ -185,12 +133,6 @@ include_directories (${sdk_root}/component/os/freertos/${freertos}/Source/includ
 
 include_directories (${sdk_root}/component/wifi/driver/include )
 include_directories (${sdk_root}/component/wifi/driver/src/osdep )
-include_directories (${sdk_root}/component/wifi/driver/src/phl )
-include_directories (${sdk_root}/component/wifi/driver/src/hal )
-include_directories (${sdk_root}/component/wifi/driver/src/hal/halmac )
-include_directories (${sdk_root}/component/wifi/driver/src/hci )
-include_directories (${sdk_root}/component/wifi/driver/src/hal/phydm/rtl8735b )
-include_directories (${sdk_root}/component/wifi/driver/src/hal/phydm )
 
 include_directories (${sdk_root}/component/lwip/${lwip}/src/include )
 include_directories (${sdk_root}/component/lwip/${lwip}/src/include/lwip )
@@ -211,6 +153,4 @@ include_directories (${sdk_root}/component/audio/3rdparty/libopusenc-0.2.1/inclu
 
 include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/video )
 include_directories (${sdk_root}/component/soc/8735b/fwlib/rtl8735b/lib/source/ram/video/semihost )
-include_directories (${sdk_root}/component/soc/8735b/cmsis/voe/rom )
-
 ]]

--- a/project/webrtc_master_demo.cmake
+++ b/project/webrtc_master_demo.cmake
@@ -49,7 +49,6 @@ set( WEBRTC_APPLICATION_MASTER_INCLUDE_DIRS
      "${REPO_ROOT_DIRECTORY}/examples/networking/networking_utils"
      "${REPO_ROOT_DIRECTORY}/examples/logging"
      "${REPO_ROOT_DIRECTORY}/configs/mbedtls"
-     "${REPO_ROOT_DIRECTORY}/configs/sigv4"
      "${REPO_ROOT_DIRECTORY}/examples/message_queue"
      "${REPO_ROOT_DIRECTORY}/examples/base64"
      "${REPO_ROOT_DIRECTORY}/examples/sdp_controller"
@@ -76,16 +75,13 @@ endif()
 include( ${REPO_ROOT_DIRECTORY}/CMake/coreHTTP.cmake )
 
 # Include sigV4
-include( ${REPO_ROOT_DIRECTORY}/libraries/crypto/SigV4-for-AWS-IoT-embedded-sdk/sigv4FilePaths.cmake )
+include( ${REPO_ROOT_DIRECTORY}/CMake/sigV4.cmake )
 
 ## Include coreJSON
 include( ${REPO_ROOT_DIRECTORY}/CMake/coreJSON.cmake )
 
 ## Include Signaling
 include( ${REPO_ROOT_DIRECTORY}/CMake/signaling.cmake )
-
-# Include signaling
-include( ${REPO_ROOT_DIRECTORY}/libraries/components/amazon-kinesis-video-streams-signaling/signalingFilePaths.cmake )
 
 # Suppress warnings for some Libraries
 file(GLOB_RECURSE WARNING_SUPPRESSED_SOURCES
@@ -131,9 +127,6 @@ include( ${REPO_ROOT_DIRECTORY}/CMake/ice.cmake )
 # Include libsrtp
 include( ${REPO_ROOT_DIRECTORY}/CMake/libsrtp.cmake )
 
-## Include sigV4
-include( ${REPO_ROOT_DIRECTORY}/CMake/sigV4.cmake )
-
 list(
 	APPEND app_flags
      HAVE_ARPA_INET_H
@@ -141,12 +134,10 @@ list(
 
 set( webrtc_master_demo_src
      ${WEBRTC_APPLICATION_MASTER_SOURCE_FILES}
-     ${SIGV4_SOURCES}
      ${WSLAY_SOURCE_FILES} )
 
 set( webrtc_master_demo_include
      ${WEBRTC_APPLICATION_MASTER_INCLUDE_DIRS}
-     ${SIGV4_INCLUDE_PUBLIC_DIRS}
      ${WSLAY_INCLUDE_DIRS} )
 
 if(BUILD_USRSCTP_LIBRARY)

--- a/project/webrtc_master_demo.cmake
+++ b/project/webrtc_master_demo.cmake
@@ -73,7 +73,7 @@ endif()
  
 # Include dependencies
 # Include coreHTTP
-include( ${REPO_ROOT_DIRECTORY}/libraries/coreHTTP/httpFilePaths.cmake )
+include( ${REPO_ROOT_DIRECTORY}/CMake/coreHTTP.cmake )
 
 # Include sigV4
 include( ${REPO_ROOT_DIRECTORY}/libraries/crypto/SigV4-for-AWS-IoT-embedded-sdk/sigv4FilePaths.cmake )
@@ -90,7 +90,6 @@ include( ${REPO_ROOT_DIRECTORY}/libraries/components/amazon-kinesis-video-stream
 # Suppress warnings for some Libraries
 file(GLOB_RECURSE WARNING_SUPPRESSED_SOURCES
     "${REPO_ROOT_DIRECTORY}/libraries/ambpro2_sdk/*.c"
-    "${REPO_ROOT_DIRECTORY}/libraries/coreHTTP/source/dependency/3rdparty/llhttp/src/llhttp.c"
 )
 
 set_source_files_properties(
@@ -143,7 +142,6 @@ list(
 
 set( webrtc_master_demo_src
      ${WEBRTC_APPLICATION_MASTER_SOURCE_FILES}
-     ${HTTP_SOURCES}
      ${SIGV4_SOURCES}
      ${WSLAY_SOURCE_FILES}
      ${SDP_SOURCES}
@@ -154,7 +152,6 @@ set( webrtc_master_demo_src
 
 set( webrtc_master_demo_include
      ${WEBRTC_APPLICATION_MASTER_INCLUDE_DIRS}
-     ${HTTP_INCLUDE_PUBLIC_DIRS}
      ${SIGV4_INCLUDE_PUBLIC_DIRS}
      ${WSLAY_INCLUDE_DIRS}
      ${SDP_INCLUDE_PUBLIC_DIRS}

--- a/project/webrtc_master_demo.cmake
+++ b/project/webrtc_master_demo.cmake
@@ -117,13 +117,13 @@ set( WSLAY_INCLUDE_DIRS
 include( ${REPO_ROOT_DIRECTORY}/CMake/sdp.cmake )
 
 # Include STUN
-include( ${REPO_ROOT_DIRECTORY}/libraries/components/amazon-kinesis-video-streams-stun/stunFilePaths.cmake )
+include( ${REPO_ROOT_DIRECTORY}/CMake/stun.cmake )
 
 # Include RTP
-include( ${REPO_ROOT_DIRECTORY}/libraries/components/amazon-kinesis-video-streams-rtp/rtpFilePaths.cmake )
+include( ${REPO_ROOT_DIRECTORY}/CMake/rtp.cmake )
 
 # Include RTCP
-include( ${REPO_ROOT_DIRECTORY}/libraries/components/amazon-kinesis-video-streams-rtcp/rtcpFilePaths.cmake )
+include( ${REPO_ROOT_DIRECTORY}/CMake/rtcp.cmake )
 
 # Include ICE
 include( ${REPO_ROOT_DIRECTORY}/CMake/ice.cmake )
@@ -142,20 +142,12 @@ list(
 set( webrtc_master_demo_src
      ${WEBRTC_APPLICATION_MASTER_SOURCE_FILES}
      ${SIGV4_SOURCES}
-     ${WSLAY_SOURCE_FILES}
-     ${STUN_SOURCES}
-     ${ICE_SOURCES}
-     ${RTP_SOURCES}
-     ${RTCP_SOURCES} )
+     ${WSLAY_SOURCE_FILES} )
 
 set( webrtc_master_demo_include
      ${WEBRTC_APPLICATION_MASTER_INCLUDE_DIRS}
      ${SIGV4_INCLUDE_PUBLIC_DIRS}
-     ${WSLAY_INCLUDE_DIRS}
-     ${STUN_INCLUDE_PUBLIC_DIRS}
-     ${ICE_INCLUDE_PUBLIC_DIRS}
-     ${RTP_INCLUDE_PUBLIC_DIRS}
-     ${RTCP_INCLUDE_PUBLIC_DIRS} )
+     ${WSLAY_INCLUDE_DIRS} )
 
 if(BUILD_USRSCTP_LIBRARY)
      # Include DCEP

--- a/project/webrtc_master_demo.cmake
+++ b/project/webrtc_master_demo.cmake
@@ -95,19 +95,7 @@ set_source_files_properties(
 )
 
 # Include wslay
-file(
-  GLOB
-  WSLAY_SOURCE_FILES
-  "${REPO_ROOT_DIRECTORY}/libraries/wslay/lib/*.c" )
-
-configure_file(${REPO_ROOT_DIRECTORY}/libraries/wslay/lib/includes/wslay/wslayver.h.in
-               ${REPO_ROOT_DIRECTORY}/libraries/wslay/lib/includes/wslay/wslayver.h @ONLY)
-
-set( WSLAY_INCLUDE_DIRS
-     "${REPO_ROOT_DIRECTORY}/libraries/wslay/lib/"
-     "${REPO_ROOT_DIRECTORY}/libraries/wslay/lib/includes"
-     "${REPO_ROOT_DIRECTORY}/libraries/wslay/lib/includes/wslay"
-     "${REPO_ROOT_DIRECTORY}/configs/wslay" )
+include( ${REPO_ROOT_DIRECTORY}/CMake/wslay.cmake )
 
 # Include SDP
 include( ${REPO_ROOT_DIRECTORY}/CMake/sdp.cmake )
@@ -127,18 +115,11 @@ include( ${REPO_ROOT_DIRECTORY}/CMake/ice.cmake )
 # Include libsrtp
 include( ${REPO_ROOT_DIRECTORY}/CMake/libsrtp.cmake )
 
-list(
-	APPEND app_flags
-     HAVE_ARPA_INET_H
-)
-
 set( webrtc_master_demo_src
-     ${WEBRTC_APPLICATION_MASTER_SOURCE_FILES}
-     ${WSLAY_SOURCE_FILES} )
+     ${WEBRTC_APPLICATION_MASTER_SOURCE_FILES} )
 
 set( webrtc_master_demo_include
-     ${WEBRTC_APPLICATION_MASTER_INCLUDE_DIRS}
-     ${WSLAY_INCLUDE_DIRS} )
+     ${WEBRTC_APPLICATION_MASTER_INCLUDE_DIRS} )
 
 if(BUILD_USRSCTP_LIBRARY)
      # Include DCEP

--- a/project/webrtc_master_demo.cmake
+++ b/project/webrtc_master_demo.cmake
@@ -170,11 +170,6 @@ if(BUILD_USRSCTP_LIBRARY)
           APPEND app_flags
           ENABLE_SCTP_DATA_CHANNEL=1
      )
-
-     list( 
-          APPEND webrtc_master_demo_include
-          ${DCEP_INCLUDE_PUBLIC_DIRS}
-     )
 else()
      list(
           APPEND app_flags

--- a/project/webrtc_master_demo.cmake
+++ b/project/webrtc_master_demo.cmake
@@ -79,7 +79,10 @@ include( ${REPO_ROOT_DIRECTORY}/libraries/coreHTTP/httpFilePaths.cmake )
 include( ${REPO_ROOT_DIRECTORY}/libraries/crypto/SigV4-for-AWS-IoT-embedded-sdk/sigv4FilePaths.cmake )
 
 ## Include coreJSON
-include( ${REPO_ROOT_DIRECTORY}/libraries/coreJSON/jsonFilePaths.cmake )
+include( ${REPO_ROOT_DIRECTORY}/CMake/coreJSON.cmake )
+
+## Include Signaling
+include( ${REPO_ROOT_DIRECTORY}/CMake/signaling.cmake )
 
 # Include signaling
 include( ${REPO_ROOT_DIRECTORY}/libraries/components/amazon-kinesis-video-streams-signaling/signalingFilePaths.cmake )
@@ -142,8 +145,6 @@ set( webrtc_master_demo_src
      ${WEBRTC_APPLICATION_MASTER_SOURCE_FILES}
      ${HTTP_SOURCES}
      ${SIGV4_SOURCES}
-     ${SIGNALING_SOURCES}
-     ${JSON_SOURCES}
      ${WSLAY_SOURCE_FILES}
      ${SDP_SOURCES}
      ${STUN_SOURCES}
@@ -155,8 +156,6 @@ set( webrtc_master_demo_include
      ${WEBRTC_APPLICATION_MASTER_INCLUDE_DIRS}
      ${HTTP_INCLUDE_PUBLIC_DIRS}
      ${SIGV4_INCLUDE_PUBLIC_DIRS}
-     ${SIGNALING_INCLUDE_PUBLIC_DIRS}
-     ${JSON_INCLUDE_PUBLIC_DIRS}
      ${WSLAY_INCLUDE_DIRS}
      ${SDP_INCLUDE_PUBLIC_DIRS}
      ${STUN_INCLUDE_PUBLIC_DIRS}

--- a/project/webrtc_master_demo.cmake
+++ b/project/webrtc_master_demo.cmake
@@ -114,7 +114,7 @@ set( WSLAY_INCLUDE_DIRS
      "${REPO_ROOT_DIRECTORY}/configs/wslay" )
 
 # Include SDP
-include( ${REPO_ROOT_DIRECTORY}/libraries/components/amazon-kinesis-video-streams-sdp/sdpFilePaths.cmake )
+include( ${REPO_ROOT_DIRECTORY}/CMake/sdp.cmake )
 
 # Include STUN
 include( ${REPO_ROOT_DIRECTORY}/libraries/components/amazon-kinesis-video-streams-stun/stunFilePaths.cmake )
@@ -136,7 +136,6 @@ include( ${REPO_ROOT_DIRECTORY}/CMake/sigV4.cmake )
 
 list(
 	APPEND app_flags
-     SDP_DO_NOT_USE_CUSTOM_CONFIG
      HAVE_ARPA_INET_H
 )
 
@@ -144,7 +143,6 @@ set( webrtc_master_demo_src
      ${WEBRTC_APPLICATION_MASTER_SOURCE_FILES}
      ${SIGV4_SOURCES}
      ${WSLAY_SOURCE_FILES}
-     ${SDP_SOURCES}
      ${STUN_SOURCES}
      ${ICE_SOURCES}
      ${RTP_SOURCES}
@@ -154,7 +152,6 @@ set( webrtc_master_demo_include
      ${WEBRTC_APPLICATION_MASTER_INCLUDE_DIRS}
      ${SIGV4_INCLUDE_PUBLIC_DIRS}
      ${WSLAY_INCLUDE_DIRS}
-     ${SDP_INCLUDE_PUBLIC_DIRS}
      ${STUN_INCLUDE_PUBLIC_DIRS}
      ${ICE_INCLUDE_PUBLIC_DIRS}
      ${RTP_INCLUDE_PUBLIC_DIRS}

--- a/project/webrtc_master_demo.cmake
+++ b/project/webrtc_master_demo.cmake
@@ -159,5 +159,8 @@ set_source_files_properties(
 )
 
 if( ENABLE_STREAMING_LOOPBACK )
-     add_definitions(-DENABLE_STREAMING_LOOPBACK)
+     list(
+          APPEND app_flags
+          ENABLE_STREAMING_LOOPBACK
+     )
 endif()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR restructures the build system to make external libraries independent CMake targets, providing better modularity.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
