### PR TITLE
Enable non-blocking mode for TURN TLS connections.

### DIFF
--- a/examples/ice_controller/ice_controller_net.c
+++ b/examples/ice_controller/ice_controller_net.c
@@ -298,8 +298,8 @@ static IceControllerResult_t CreateSocketContextTcp( IceControllerContext_t * pC
                                                pRemoteIpPos,
                                                pConnectEndpoint->transportAddress.port,
                                                &credentials,
-                                               1,
-                                               1,
+                                               0U,
+                                               0U,
                                                TLS_CONNECT_NON_BLOCKING_HANDSHAKE );
 
         if( xNetworkStatus == TLS_TRANSPORT_HANDSHAKE_IN_PROGRESS )

--- a/examples/network_transport/tcp_sockets_wrapper/ports/lwip/tcp_sockets_wrapper.c
+++ b/examples/network_transport/tcp_sockets_wrapper/ports/lwip/tcp_sockets_wrapper.c
@@ -115,28 +115,29 @@ BaseType_t TCP_Sockets_Connect( Socket_t * pTcpSocket,
 
     if( xRet == TCP_SOCKETS_ERRNO_NONE )
     {
-        setsockopt( xFd, SOL_SOCKET, SO_RCVTIMEO, &receiveTimeoutMs, sizeof( receiveTimeoutMs ) );
-        setsockopt( xFd, SOL_SOCKET, SO_SNDTIMEO, &sendTimeoutMs, sizeof( sendTimeoutMs ) );
-    }
-
-    if( ( xRet == TCP_SOCKETS_ERRNO_NONE ) &&
-        ( receiveTimeoutMs == 0 ) &&
-        ( sendTimeoutMs == 0 ) )
-    {
-        fcntlFlags = fcntl( xFd, F_GETFL, 0 );
-        if( fcntlFlags < 0 )
+        if( ( receiveTimeoutMs == 0 ) &&
+            ( sendTimeoutMs == 0 ) )
         {
-            LogError( ( "fcntl() failed with errno: %d", errno ) );
-            xRet = TCP_SOCKETS_ERRNO_ERROR;
-        }
-        else
-        {
-            fcntlFlags |= O_NONBLOCK;
-            if( fcntl( xFd, F_SETFL, fcntlFlags ) < 0 )
+            fcntlFlags = fcntl( xFd, F_GETFL, 0 );
+            if( fcntlFlags < 0 )
             {
                 LogError( ( "fcntl() failed with errno: %d", errno ) );
                 xRet = TCP_SOCKETS_ERRNO_ERROR;
             }
+            else
+            {
+                fcntlFlags |= O_NONBLOCK;
+                if( fcntl( xFd, F_SETFL, fcntlFlags ) < 0 )
+                {
+                    LogError( ( "fcntl() failed with errno: %d", errno ) );
+                    xRet = TCP_SOCKETS_ERRNO_ERROR;
+                }
+            }
+        }
+        else
+        {
+            setsockopt( xFd, SOL_SOCKET, SO_RCVTIMEO, &receiveTimeoutMs, sizeof( receiveTimeoutMs ) );
+            setsockopt( xFd, SOL_SOCKET, SO_SNDTIMEO, &sendTimeoutMs, sizeof( sendTimeoutMs ) );
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
The offer-to-answer latency is more than expectation.

*Description of changes:*
This pull request adds support for non-blocking TURN TLS connections when both receive and send timeouts are set to zero. The changes include:
1. Instead of setting send/recv timeout of socket handler, we configure it into non-blocking mode for TURN TLS connection.
2. Updated ice_controller_net.c to use zero timeouts (0U) for TLS connections instead of 1ms timeouts to set it into non-blocking mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
