### PR TITLE
Close websocket connection properly.

### DIFF
--- a/examples/networking/wslay_helper/wslay_helper.c
+++ b/examples/networking/wslay_helper/wslay_helper.c
@@ -1656,7 +1656,6 @@ WebsocketResult_t Websocket_Disconnect( NetworkingWslayContext_t * pWebsocketCtx
     {
         if( pWebsocketCtx->wslayContext != NULL )
         {
-            pWebsocketCtx->connectionEstablished = 0U;
             pWebsocketCtx->connectionCloseRequested = 0U;
 
             /* Shutdown WebSocket read operations */


### PR DESCRIPTION
*Issue #, if available:*
When the websocket connection closed by remote happens multiple times, the application fails to create socket handlers due to "no enough memory".


*Description of changes:*
Remove the incorrect reset line in disconnection function to close TLS connection properly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
