### PR TITLE
Centralize NAT traversal configuration in AppContext

### DIFF
--- a/examples/app_common/app_common.c
+++ b/examples/app_common/app_common.c
@@ -231,7 +231,7 @@ static int32_t StartPeerConnectionSession( AppContext_t * pAppContext,
         #endif /* #if defined( AWS_CA_CERT_PEM ) */
 
         pcConfig.canTrickleIce = 1U;
-        pcConfig.natTraversalConfigBitmap = ICE_CANDIDATE_NAT_TRAVERSAL_CONFIG_ALLOW_ALL;
+        pcConfig.natTraversalConfigBitmap = pAppContext->natTraversalConfig;
 
         ret = GetIceServerList( pAppContext,
                                 pcConfig.iceServers,
@@ -748,7 +748,7 @@ static int32_t InitializeAppSession( AppContext_t * pAppContext,
             0,
             sizeof( PeerConnectionSessionConfiguration_t ) );
     pcConfig.canTrickleIce = 1U;
-    pcConfig.natTraversalConfigBitmap = ICE_CANDIDATE_NAT_TRAVERSAL_CONFIG_ALLOW_ALL;
+    pcConfig.natTraversalConfigBitmap = pAppContext->natTraversalConfig;
 
     peerConnectionResult = PeerConnection_Init( &pAppSession->peerConnectionSession,
                                                 &pcConfig );
@@ -1436,6 +1436,7 @@ int AppCommon_Init( AppContext_t * pAppContext,
         Sctp_Init();
         #endif /* ENABLE_SCTP_DATA_CHANNEL */
 
+        pAppContext->natTraversalConfig = ICE_CANDIDATE_NAT_TRAVERSAL_CONFIG_ALLOW_ALL;
         pAppContext->initTransceiverFunc = initTransceiverFunc;
         pAppContext->pAppMediaSourcesContext = pMediaContext;
     }

--- a/examples/app_common/app_common.h
+++ b/examples/app_common/app_common.h
@@ -67,6 +67,8 @@ typedef struct AppContext
     /* Media context. */
     InitTransceiverFunc_t initTransceiverFunc;
     AppMediaSourcesContext_t * pAppMediaSourcesContext;
+
+    IceControllerNatTraversalConfig_t natTraversalConfig;
 } AppContext_t;
 
 int AppCommon_Init( AppContext_t * pAppContext,


### PR DESCRIPTION
Description of changes:
Refactor NAT traversal configuration management to eliminate duplicate configuration and improve maintainability.

Changes:
1. Added natTraversalConfig field to AppContext_t structure to store the NAT traversal configuration
2. Initialized natTraversalConfig in AppCommon_Init with ICE_CANDIDATE_NAT_TRAVERSAL_CONFIG_ALLOW_ALL
3. Modified InitializeAppSession and StartPeerConnectionSession to use the centralized configuration from AppContext
4. Removed duplicate NAT traversal configuration assignments

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.