### PR TITLE
Separate MULAW/ALAW while adding transceiver.

### DIFF
--- a/examples/app_media_source/app_media_source.c
+++ b/examples/app_media_source/app_media_source.c
@@ -531,9 +531,10 @@ int32_t AppMediaSource_InitAudioTransceiver( AppMediaSourcesContext_t * pCtx,
         #if ( AUDIO_OPUS )
         TRANSCEIVER_ENABLE_CODEC( pAudioTranceiver->codecBitMap,
                                   TRANSCEIVER_RTC_CODEC_OPUS_BIT );
-        #else
+        #elif ( AUDIO_G711_MULAW )
         TRANSCEIVER_ENABLE_CODEC( pAudioTranceiver->codecBitMap,
                                   TRANSCEIVER_RTC_CODEC_MULAW_BIT );
+        #elif ( AUDIO_G711_ALAW )
         TRANSCEIVER_ENABLE_CODEC( pAudioTranceiver->codecBitMap,
                                   TRANSCEIVER_RTC_CODEC_ALAW_BIT );
         #endif


### PR DESCRIPTION
*Issue #, if available:*
By enabling Advanced -> Enable codec filter -> audio/PCMA only on test page, the application failed to reply correct SDP answer even though it has configured `AUDIO_G711_ALAW` in demo_config.h.

*Description of changes:*
Separate MULAW/ALAW while adding transceiver.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
